### PR TITLE
Ignore Medium's comments

### DIFF
--- a/blog-post-workflow.js
+++ b/blog-post-workflow.js
@@ -1,9 +1,9 @@
-const process = require('process');
-let Parser = require('rss-parser');
-const core = require('@actions/core');
-const _ = require('lodash');
-const fs = require('fs');
-const { spawn } = require('child_process');
+const process = require('process')
+let Parser = require('rss-parser')
+const core = require('@actions/core')
+const _ = require('lodash')
+const fs = require('fs')
+const { spawn } = require('child_process')
 
 /**
  * Builds the new readme by replacing the readme's <!-- BLOG-POST-LIST:START --><!-- BLOG-POST-LIST:END --> tags
@@ -12,20 +12,20 @@ const { spawn } = require('child_process');
  * @return {string}: content after combining previousContent and newContent
  */
 const buildReadme = (previousContent, newContent) => {
-    const tagNameInput = core.getInput('comment_tag_name');
-    const tagToLookFor = tagNameInput ? `<!-- ${tagNameInput}:` : `<!-- BLOG-POST-LIST:`;
-    const closingTag = '-->';
+    const tagNameInput = core.getInput('comment_tag_name')
+    const tagToLookFor = tagNameInput ? `<!-- ${tagNameInput}:` : `<!-- BLOG-POST-LIST:`
+    const closingTag = '-->'
     const startOfOpeningTagIndex = previousContent.indexOf(
         `${tagToLookFor}START`,
-    );
+    )
     const endOfOpeningTagIndex = previousContent.indexOf(
         closingTag,
         startOfOpeningTagIndex,
-    );
+    )
     const startOfClosingTagIndex = previousContent.indexOf(
         `${tagToLookFor}END`,
         endOfOpeningTagIndex,
-    );
+    )
     if (
         startOfOpeningTagIndex === -1 ||
         endOfOpeningTagIndex === -1 ||
@@ -39,8 +39,8 @@ const buildReadme = (previousContent, newContent) => {
         newContent,
         '\n',
         previousContent.slice(startOfClosingTagIndex),
-    ].join('');
-};
+    ].join('')
+}
 
 /**
  * Code to do git commit
@@ -48,18 +48,18 @@ const buildReadme = (previousContent, newContent) => {
  */
 const commitReadme = async () => {
     const exec = (cmd, args = []) => new Promise((resolve, reject) => {
-        console.log(`Started: ${cmd} ${args.join(' ')}`);
-        const app = spawn(cmd, args, {stdio: 'inherit'});
+        console.log(`Started: ${cmd} ${args.join(' ')}`)
+        const app = spawn(cmd, args, { stdio: 'inherit' })
         app.on('close', (code) => {
             if (code !== 0) {
-                err = new Error(`Invalid status code: ${code}`);
-                err.code = code;
-                return reject(err);
+                err = new Error(`Invalid status code: ${code}`)
+                err.code = code
+                return reject(err)
             }
-            return resolve(code);
-        });
-        app.on('error', reject);
-    });
+            return resolve(code)
+        })
+        app.on('error', reject)
+    })
 
     // Doing commit and push
     await exec('git', [
@@ -67,127 +67,126 @@ const commitReadme = async () => {
         '--global',
         'user.email',
         'blog-post-bot@example.com',
-    ]);
+    ])
     if (GITHUB_TOKEN) {
         // git remote set-url origin
-        await exec('git', ['remote', 'set-url', 'origin', `https://${GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
+        await exec('git', ['remote', 'set-url', 'origin', `https://${GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`])
     }
-    await exec('git', ['config', '--global', 'user.name', 'blog-post-bot']);
-    await exec('git', ['add', README_FILE_PATH]);
-    await exec('git', ['commit', '-m', 'Updated with latest blog posts']);
-    await exec('git', ['push']);
-    core.info("Readme updated successfully in the upstream repository");
+    await exec('git', ['config', '--global', 'user.name', 'blog-post-bot'])
+    await exec('git', ['add', README_FILE_PATH])
+    await exec('git', ['commit', '-m', 'Updated with latest blog posts'])
+    await exec('git', ['push'])
+    core.info("Readme updated successfully in the upstream repository")
     // Making job fail if one of the source fails
-    jobFailFlag ? process.exit(1) : process.exit(0);
-};
+    jobFailFlag ? process.exit(1) : process.exit(0)
+}
 
 
 // Blog workflow code
 
-let parser = new Parser();
+let parser = new Parser()
 // Total no of posts to display on readme, all sources combined, default: 5
-const TOTAL_POST_COUNT = Number.parseInt(core.getInput('max_post_count'));
+const TOTAL_POST_COUNT = Number.parseInt(core.getInput('max_post_count'))
 // Readme path, default: ./README.md
-const README_FILE_PATH = core.getInput('readme_path');
-const GITHUB_TOKEN = core.getInput('gh_token');
-core.setSecret(GITHUB_TOKEN);
+const README_FILE_PATH = core.getInput('readme_path')
+const GITHUB_TOKEN = core.getInput('gh_token')
+core.setSecret(GITHUB_TOKEN)
 
-const promiseArray = []; // Runner
-const runnerNameArray = []; // To show the error/success message
-let postsArray = []; // Array to store posts
-let jobFailFlag = false; // Job status flag
+const promiseArray = [] // Runner
+const runnerNameArray = [] // To show the error/success message
+let postsArray = [] // Array to store posts
+let jobFailFlag = false // Job status flag
 
-const feedObjString = core.getInput('feed_list').trim();
-
-function ignoreMediumComments (post) {
-    
+const feedObjString = core.getInput('feed_list').trim()
 
 // Reading feed list from the workflow input
-let feedList = feedObjString.split(',');
+let feedList = feedObjString.split(',')
 if (feedList.length === 0) {
-    core.error("Please double check the value of feed_list");
-    process.exit(1);
+    core.error("Please double check the value of feed_list")
+    process.exit(1)
+}
+
+function ignoreMediumComments (item) { // filters out every medium comment
+    if (item['link'].includes('medium.com') && item['categories'] === undefined) return false
+    return true
 }
 
 feedList.forEach((siteUrl) => {
-    runnerNameArray.push(siteUrl);
+    runnerNameArray.push(siteUrl)
     promiseArray.push(new Promise((resolve, reject) => {
         parser.parseURL(siteUrl).then((data) => {
-            const responsePosts = _.get(data, 'items');
+            const responsePosts = _.get(data, 'items')
             if (responsePosts === undefined) {
-                reject("Cannot read response->item");
+                reject("Cannot read response->item")
             } else {
                 const posts = responsePosts
-                .filter((item) => { // filters out every medium comment
-                    if (siteUrl.includes('medium.com/feed') && item['category'] === undefined) return false
-                    return true
-                })
-                .map((item) => {
-                    // Validating keys to avoid errors
-                    if (item['pubDate'] === undefined) {
-                        reject("Cannot read response->item->pubDate");
-                    }
-                    if (item['title'] === undefined) {
-                        reject("Cannot read response->item->title");
-                    }
-                    if (item['link'] === undefined) {
-                        reject("Cannot read response->item->link");
-                    }
-                    return {
-                        title: item.title,
-                        url: item.link,
-                        date: new Date(item.pubDate)
-                    };
-                });
-                resolve(posts);
+                    .filter(ignoreMediumComments)
+                    .map((item) => {
+                        // Validating keys to avoid errors
+                        if (item['pubDate'] === undefined) {
+                            reject("Cannot read response->item->pubDate")
+                        }
+                        if (item['title'] === undefined) {
+                            reject("Cannot read response->item->title")
+                        }
+                        if (item['link'] === undefined) {
+                            reject("Cannot read response->item->link")
+                        }
+                        return {
+                            title: item.title,
+                            url: item.link,
+                            date: new Date(item.pubDate)
+                        }
+                    })
+                resolve(posts)
             }
-        }).catch(reject);
-    }));
-});
+        }).catch(reject)
+    }))
+})
 
 // Processing the generated promises
 Promise.allSettled(promiseArray).then((results) => {
     results.forEach((result, index) => {
         if (result.status === "fulfilled") {
             // Succeeded
-            core.info(runnerNameArray[index] + ' runner succeeded. Post count: ' + result.value.length);
-            postsArray.push(...result.value);
+            core.info(runnerNameArray[index] + ' runner succeeded. Post count: ' + result.value.length)
+            postsArray.push(...result.value)
         } else {
-            jobFailFlag = true;
+            jobFailFlag = true
             // Rejected
-            core.error(runnerNameArray[index] + ' runner failed, please verify the configuration. Error:');
-            core.error(result.reason);
+            core.error(runnerNameArray[index] + ' runner failed, please verify the configuration. Error:')
+            core.error(result.reason)
         }
-    });
+    })
 }).finally(() => {
     // Sorting posts based on date
     postsArray.sort(function (a, b) {
-        return b.date - a.date;
-    });
+        return b.date - a.date
+    })
     // Slicing with the max count
-    postsArray = postsArray.slice(0, TOTAL_POST_COUNT);
+    postsArray = postsArray.slice(0, TOTAL_POST_COUNT)
     if (postsArray.length > 0) {
         try {
-            const readmeData = fs.readFileSync(README_FILE_PATH, "utf8");
+            const readmeData = fs.readFileSync(README_FILE_PATH, "utf8")
 
             const postListMarkdown = postsArray.reduce((acc, cur, index) => {
-                return acc + `- [${cur.title}](${cur.url})` + ((index === (postsArray.length - 1)) ? '' : '\n');
-            }, '');
-            const newReadme = buildReadme(readmeData, postListMarkdown);
+                return acc + `- [${cur.title}](${cur.url})` + ((index === (postsArray.length - 1)) ? '' : '\n')
+            }, '')
+            const newReadme = buildReadme(readmeData, postListMarkdown)
             // if there's change in readme file update it
             if (newReadme !== readmeData) {
-                core.info('Writing to ' + README_FILE_PATH);
-                fs.writeFileSync(README_FILE_PATH, newReadme);
+                core.info('Writing to ' + README_FILE_PATH)
+                fs.writeFileSync(README_FILE_PATH, newReadme)
                 if (!process.env.TEST_MODE) {
-                    commitReadme();
+                    commitReadme()
                 }
             } else {
-                core.info('No change detected, skipping');
+                core.info('No change detected, skipping')
                 process.exit(0)
             }
         } catch (e) {
-            core.error(e);
-            process.exit(1);
+            core.error(e)
+            process.exit(1)
         }
     }
-});
+})

--- a/blog-post-workflow.js
+++ b/blog-post-workflow.js
@@ -99,6 +99,8 @@ let jobFailFlag = false; // Job status flag
 
 const feedObjString = core.getInput('feed_list').trim();
 
+function ignoreMediumComments (post) {
+    
 
 // Reading feed list from the workflow input
 let feedList = feedObjString.split(',');
@@ -115,10 +117,12 @@ feedList.forEach((siteUrl) => {
             if (responsePosts === undefined) {
                 reject("Cannot read response->item");
             } else {
-                const posts = responsePosts.map((item) => {
-                    // Ignore Medium's comments
-                    if (siteUrl.includes('medium.com/feed') && item['category'] === undefined) return
-                    
+                const posts = responsePosts
+                .filter((item) => { // filters out every medium comment
+                    if (siteUrl.includes('medium.com/feed') && item['category'] === undefined) return false
+                    return true
+                })
+                .map((item) => {
                     // Validating keys to avoid errors
                     if (item['pubDate'] === undefined) {
                         reject("Cannot read response->item->pubDate");

--- a/blog-post-workflow.js
+++ b/blog-post-workflow.js
@@ -106,7 +106,7 @@ if (feedList.length === 0) {
     process.exit(1)
 }
 
-function ignoreMediumComments (item) { // filters out every medium comment
+function ignoreMediumComments (item) { // filters out every medium comment (PR #4)
     if (item['link'].includes('medium.com') && item['categories'] === undefined) return false
     return true
 }

--- a/blog-post-workflow.js
+++ b/blog-post-workflow.js
@@ -116,6 +116,9 @@ feedList.forEach((siteUrl) => {
                 reject("Cannot read response->item");
             } else {
                 const posts = responsePosts.map((item) => {
+                    // Ignore Medium's comments
+                    if (siteUrl.includes('medium.com/feed') && item['category'] === undefined) return
+                    
                     // Validating keys to avoid errors
                     if (item['pubDate'] === undefined) {
                         reject("Cannot read response->item->pubDate");

--- a/blog-post-workflow.js
+++ b/blog-post-workflow.js
@@ -106,10 +106,8 @@ if (feedList.length === 0) {
     process.exit(1)
 }
 
-function ignoreMediumComments (item) { // filters out every medium comment (PR #4)
-    if (item['link'].includes('medium.com') && item['categories'] === undefined) return false
-    return true
-}
+// filters out every medium comment (PR #4)
+const ignoreMediumComments = (item) => item['link'].includes('medium.com') && item['categories'] === undefined ? false : true
 
 feedList.forEach((siteUrl) => {
     runnerNameArray.push(siteUrl)
@@ -148,6 +146,7 @@ feedList.forEach((siteUrl) => {
 Promise.allSettled(promiseArray).then((results) => {
     results.forEach((result, index) => {
         if (result.status === "fulfilled") {
+            console.log(result)
             // Succeeded
             core.info(runnerNameArray[index] + ' runner succeeded. Post count: ' + result.value.length)
             postsArray.push(...result.value)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blog-post-workflow",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
-const process = require('process');
-const path = require('path');
-const fs = require('fs');
+const process = require('process')
+const path = require('path')
+const fs = require('fs')
 // language=markdown
 const template = `# Readme test
 Post list example:
@@ -9,13 +9,13 @@ Post list example:
 
 # Other contents
 Test content
-`;
-fs.writeFile(path.join(__dirname, 'test', 'Readme.md'), template, ()=> {
-    console.log("Written test file....");
-    process.env.INPUT_MAX_POST_COUNT = "5";
-    process.env.INPUT_FEED_LIST = "http://localhost:8080";
-    process.env.INPUT_README_PATH = path.join(__dirname, 'test', 'Readme.md');
-    process.env.TEST_MODE = "true";
-    require('./blog-post-workflow');
-});
+`
+fs.writeFile(path.join(__dirname, 'test', 'Readme.md'), template, () => {
+    console.log("Written test file....")
+    process.env.INPUT_MAX_POST_COUNT = "5"
+    process.env.INPUT_FEED_LIST = "http://localhost:8080"
+    process.env.INPUT_README_PATH = path.join(__dirname, 'test', 'Readme.md')
+    process.env.TEST_MODE = "true"
+    require('./blog-post-workflow')
+})
 

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -25,6 +25,21 @@
             <category>webdev</category>
         </item>
         <item>
+            <title>
+                <![CDATA[ Opa cara fico muito feliz por ler isso! ]]>
+            </title>
+            <link>https://medium.com/@khaosdoctor/opa-cara-fico-muito-feliz-por-ler-isso-ec0567da7d68?source=rss-84c42a22cef7------2</link>
+            <guid isPermaLink="false">https://medium.com/p/ec0567da7d68</guid>
+            <dc:creator>
+                <![CDATA[ Lucas Santos ]]>
+            </dc:creator>
+            <pubDate>Mon, 18 May 2020 16:10:51 GMT</pubDate>
+            <atom:updated>2020-05-18T16:10:51.564Z</atom:updated>
+            <content:encoded>
+                <![CDATA[ <p>Opa cara fico muito feliz por ler isso! Espero que você comece sim a escrever! E pode me mandar seus artigos sem problemas! Vou adorar revisá-los :)</p><img src="https://medium.com/_/stat?event=post.clientViewed&referrerSource=full_rss&postId=ec0567da7d68" width="1" height="1"> ]]>
+            </content:encoded>
+        </item>
+        <item>
             <title>Skipping the Chrome "Your connection is not private" warning</title>
             <author>Gautam krishna.R</author>
             <pubDate>Sun, 03 May 2020 15:14:39 +0000</pubDate>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -26,17 +26,17 @@
         </item>
         <item>
             <title>
-                <![CDATA[ Opa cara fico muito feliz por ler isso! ]]>
+                <![CDATA[ Should be ignored! ]]>
             </title>
-            <link>https://medium.com/@khaosdoctor/opa-cara-fico-muito-feliz-por-ler-isso-ec0567da7d68?source=rss-84c42a22cef7------2</link>
+            <link>https://medium.com/@user/should-be-ignored-ec0567da7d68?source=rss-84c42a22cef7------2</link>
             <guid isPermaLink="false">https://medium.com/p/ec0567da7d68</guid>
             <dc:creator>
-                <![CDATA[ Lucas Santos ]]>
+                <![CDATA[ User ]]>
             </dc:creator>
             <pubDate>Mon, 18 May 2020 16:10:51 GMT</pubDate>
             <atom:updated>2020-05-18T16:10:51.564Z</atom:updated>
             <content:encoded>
-                <![CDATA[ <p>Opa cara fico muito feliz por ler isso! Espero que você comece sim a escrever! E pode me mandar seus artigos sem problemas! Vou adorar revisá-los :)</p><img src="https://medium.com/_/stat?event=post.clientViewed&referrerSource=full_rss&postId=ec0567da7d68" width="1" height="1"> ]]>
+                <![CDATA[ <p>This comment should be ignored</p></p><img src="https://medium.com/_/stat?event=post.clientViewed&referrerSource=full_rss&postId=ec0567da7d68" width="1" height="1"> ]]>
             </content:encoded>
         </item>
         <item>


### PR DESCRIPTION
Medium treats comments as blog posts. This way all comments appear on the feed, but they don't have categories as normal articles do:

![image](https://user-images.githubusercontent.com/3200560/88223215-779bec00-cc3d-11ea-9791-5988ece5f91d.png)

Adding a condition to check if the `siteUrl` contains the `medium.com/feed` keywords, if so, checks if the item contains at least one category. If it does, then continues, if not return empty.

