### PR TITLE
Add action typing declaration

### DIFF
--- a/.github/workflows/check-action-typing.yml
+++ b/.github/workflows/check-action-typing.yml
@@ -1,0 +1,14 @@
+name: Check action typing
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+
+jobs:
+  "check-action-typing":
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: krzema12/github-actions-typing@v0
+

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,78 @@
+# See https://github.com/krzema12/github-actions-typing
+typingSpec: krzema12/github-actions-typing@v0.3
+inputs:
+  gh_token:
+    type: string
+  readme_path:
+    type: list
+    separator: ','
+    listItem:
+      type: string
+  max_post_count:
+    type: integer
+  feed_list:
+    type: list
+    separator: ','
+    listItem:
+      type: string
+  disable_sort:
+    type: boolean
+  filter_comments:
+    type: list
+    separator: ','
+    listItem:
+      type: string
+  tag_post_pre_newline:
+    type: boolean
+  template:
+    type: string
+  date_format:
+    type: string
+  comment_tag_name:
+    type: string
+  user_agent:
+    type: string
+  accept_header:
+    type: string
+  custom_tags:
+    type: list
+    separator: ','
+    listItem:
+      type: string
+  title_max_length:
+    type: integer
+  description_max_length:
+    type: integer
+  item_exec:
+    type: string
+  commit_message:
+    type: string
+  committer_username:
+    type: string
+  committer_email:
+    type: string
+  output_only:
+    type: boolean
+  enable_keepalive:
+    type: boolean
+  retry_count:
+    type: integer
+  retry_wait_time:
+    type: integer
+  feed_names:
+    type: list
+    separator: ','
+    listItem:
+      type: string
+  disable_html_encoding:
+    type: boolean
+  categories_template:
+    type: string
+  disable_item_validation:
+    type: boolean
+  filter_dates:
+    type: string
+outputs:
+  results:
+    type: string
+


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our contribution guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update, kinda :)

We're working on bringing more type-safety to GitHub Actions world! While working on [this Kotlin DSL](https://github.com/krzema12/github-actions-kotlin-dsl/) for writing GitHub workflows, it's needed to specify types of inputs for each supported action. For your action, it's [this piece](https://github.com/krzema12/github-actions-kotlin-dsl/blob/e3b74321487d0b0c3861340f5de182be9c6bb218/wrapper-generator/src/main/kotlin/it/krzeminski/githubactions/wrappergenerator/WrappersToGenerate.kt#L607-L627) of our config file. It's tedious to maintain such typings by one team and it doesn't scale well with the number of actions.

That's why we came up with https://github.com/krzema12/github-actions-typing - an attempt to introduce a standard to describe types in actions' APIs. The mentioned repo is both a reference implementation which describes the format of the extra `action-types.yml` file, but also a GitHub action itself that validates this file and warns if some illegal type is defined there. I'm including a workflow that runs this in this PR.

Since you're one of the first action maintainers we're reaching out to, we're
looking forward for feedback! We're hoping to have you as one of early adopters,
it would help bringing the idea of types declaration standardization further.

Context: https://github.com/krzema12/github-actions-kotlin-dsl/issues/302

* **What is the current behavior?** (You can also link to an open issue here)
The action doesn't specify types of its inputs and outputs.


* **What is the new behavior (if this is a feature change)?**
Types are defined and maintained by you, the action maintainer. Others can benefit from it in numerous ways, including having a standardized way of documenting types and being able to use type-safe DSLs like the Kotlin one.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
* 
No.

* **Other information**:
